### PR TITLE
Remove fixed peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "node": ">=12.13.0"
       },
       "peerDependencies": {
-        "typescript": "^4.3.5 || ^5",
         "typescript-to-lua": "^1.0.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "node": ">=12.13.0"
       },
       "peerDependencies": {
-        "typescript": "~4.3.5",
+        "typescript": "^4.3.5 || ^5",
         "typescript-to-lua": "^1.0.0"
       }
     },
@@ -8080,7 +8080,8 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
       "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -10332,7 +10333,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "26.0.0",
@@ -12645,7 +12647,8 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
       "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "typescript": "^4.3.5 || ^5",
     "typescript-to-lua": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "typescript": "~4.3.5",
+    "typescript": "^4.3.5 || ^5",
     "typescript-to-lua": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The tsd-templates are currently blocked from upgrading their version of TypeScript because of the narrow peerDependency in this project.

Ongoing discussion in ts-defold/tstl-export-as-global#1

Changes:
- Removed typescript as a peer dependency

Unblocks:
- ts-defold/tsd-template#36
- ts-defold/tsd-template-war-battles#23
- ts-defold/tsd-template-yagames#19
- ts-defold/tsd-template-web-monetized#28